### PR TITLE
correcting einsum eqivalent of outer

### DIFF
--- a/_posts/2015-5-02-Basic-guide-to-einsum.md
+++ b/_posts/2015-5-02-Basic-guide-to-einsum.md
@@ -135,7 +135,7 @@ Let `A` and `B` be two 1D arrays of compatible shapes (meaning the lengths of th
     <td class="tg-yw4l">inner product of A and B</td>
   </tr>
   <tr>
-    <td class="tg-yw4l"><code>('i,j', A, B)</code></td>
+    <td class="tg-yw4l"><code>('i,j->ij', A, B)</code></td>
     <td class="tg-yw4l"><code>outer(A, B)</code></td>
     <td class="tg-yw4l">outer product of A and B</td>
   </tr>


### PR DESCRIPTION
Currently `('i,j', A, B)` which is `np.sum(np.outer(A,B))`. One needs `('i,j->ij', A, B)`.